### PR TITLE
Make allow-hosts not override other allow-hosts

### DIFF
--- a/buildout-cache.cfg
+++ b/buildout-cache.cfg
@@ -4,7 +4,7 @@ download-cache = buildout-cache/downloads
 plone-series =
 basename = Plone-${versions:Plone}-UnifiedInstaller
 filename = ${buildout:basename}.tgz
-allow-hosts =
+allow-hosts +=
     *.plone.org
     *.python.org
     *.zope.org


### PR DESCRIPTION
I have a client buildout config in which I extend buildout-cache.cfg and the allow-hosts from the latter overrides the former.

With this fix, the allow-hosts in buildout-cache simply adds values, not overrides them.
