### PR TITLE
Add robotframework site and code.google.com to allowed-hosts

### DIFF
--- a/buildout-cache.cfg
+++ b/buildout-cache.cfg
@@ -11,6 +11,8 @@ allow-hosts =
     docutils.sourceforge.net
     effbot.org
     prdownloads.sourceforge.net
+    code.google.com
+    robotframework.googlecode.com
 
 [download]
 recipe = hexagonit.recipe.download


### PR DESCRIPTION
Without these two lines I was unable to run buildout:
it couldn't find the robotframework egg.
