### PR TITLE
do code analysis only in src directory

### DIFF
--- a/qa.cfg
+++ b/qa.cfg
@@ -10,7 +10,7 @@ package-pep8-ignores = E501
 
 [code-analysis]
 recipe = plone.recipe.codeanalysis
-directory = .
+directory = src
 pre-commit-hook = True
 flake8 = True
 flake8-ignore = E501


### PR DESCRIPTION
So we can commit even if we have pyflakes warnings, for instance, in parts
