### PR TITLE
Show picked versions

### DIFF
--- a/plone-4.2.x.cfg
+++ b/plone-4.2.x.cfg
@@ -13,6 +13,8 @@ parts = instance
 
 package-name =
 
+show-picked-versions = true
+
 [versions]
 
 [instance]

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -13,6 +13,8 @@ parts = instance
 
 package-name =
 
+show-picked-versions = true
+
 [versions]
 
 [instance]

--- a/plone-4.x.cfg
+++ b/plone-4.x.cfg
@@ -13,6 +13,8 @@ parts = instance
 
 package-name =
 
+show-picked-versions = true
+
 [versions]
 
 [instance]

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -12,6 +12,8 @@ parts = instance
 
 package-name =
 
+show-picked-versions = true
+
 [versions]
 
 [instance]

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -13,6 +13,8 @@ parts = instance
 
 package-name =
 
+show-picked-versions = true
+
 [versions]
 
 [instance]

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -12,6 +12,8 @@ parts = instance
 
 package-name =
 
+show-picked-versions = true
+
 [versions]
 
 [instance]


### PR DESCRIPTION
This allows to see which versions have been picked for the distributions
not pinned on [versions] sections.

See https://pypi.python.org/pypi/zc.buildout/2.5.2#easier-reporting-and-managing-of-versions-new-in-buildout-2-0

I would actually use ``allow-picked-versions = false`` to make buildout fail if there are versions not pinned (that's the only way to get a 100% repeatable buildout), but that can cause way too many breakage...