### PR TITLE
On CI environments run createcoverage without opening a browser.

### DIFF
--- a/qa.cfg
+++ b/qa.cfg
@@ -44,7 +44,17 @@ input = inline:
     fi
 
     if [ ! -f "$REPORT" ]; then
-        bin/createcoverage run bin/test
+        if [ "$CI" ]; then
+            # Use output dir to prevent opening a browser.
+            bin/createcoverage --output-dir=htmlcov
+        else
+            bin/createcoverage
+        fi
+    fi
+
+    if [ ! -f "$REPORT" ]; then
+        echo "createcoverage went wrong: $REPORT does not exist"
+        exit 1
     fi
 
     # find first percentage value in file (module test coverage) and return it


### PR DESCRIPTION
Also, we were previously calling 'bin/createcoverage run bin/test'. The 'run bin/test' part is useless, so I removed it.  Maybe it was needed in previous versions.

Also, when createcoverage fails to create a report, bail out early. Otherwise you get confusing grep and bash errors.

We check the $CI environment variable to see if we are on a Continuous Integration machine.  This at least works for Travis:
https://docs.travis-ci.com/user/environment-variables#Default-Environment-Variables

In that case, run bin/createcoverage with the `--output-dir` option. This has the side effect of not opening a browser to view the results. This has two reasons:
1. There is no user who can look at the results, so it is useless.
2. Travis fails to kill the browser at the end, so the build never finishes.
See https://github.com/reinout/createcoverage/issues/5

Sample failing build:
https://travis-ci.org/collective/collective.watcherlist/jobs/185787861

cc @hvelarde 