### PR TITLE
Pin zc.recipe.cmmi to 1.3.6

### DIFF
--- a/plone-4.0.x.cfg
+++ b/plone-4.0.x.cfg
@@ -14,6 +14,8 @@ parts = instance
 package-name =
 
 [versions]
+# https://github.com/collective/buildout.plonetest/issues/25
+zc.recipe.cmmi = 1.3.6
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-4.1.x.cfg
+++ b/plone-4.1.x.cfg
@@ -14,6 +14,8 @@ parts = instance
 package-name =
 
 [versions]
+# https://github.com/collective/buildout.plonetest/issues/25
+zc.recipe.cmmi = 1.3.6
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-4.2.x.cfg
+++ b/plone-4.2.x.cfg
@@ -16,6 +16,8 @@ package-name =
 show-picked-versions = true
 
 [versions]
+# https://github.com/collective/buildout.plonetest/issues/25
+zc.recipe.cmmi = 1.3.6
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -16,6 +16,9 @@ package-name =
 show-picked-versions = true
 
 [versions]
+# FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
+# https://github.com/collective/buildout.plonetest/issues/25
+zc.recipe.cmmi = 1.3.6
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-4.x.cfg
+++ b/plone-4.x.cfg
@@ -16,6 +16,8 @@ package-name =
 show-picked-versions = true
 
 [versions]
+# https://github.com/collective/buildout.plonetest/issues/25
+zc.recipe.cmmi = 1.3.6
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -15,6 +15,9 @@ package-name =
 show-picked-versions = true
 
 [versions]
+# FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
+# https://github.com/collective/buildout.plonetest/issues/25
+zc.recipe.cmmi = 1.3.6
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -16,6 +16,9 @@ package-name =
 show-picked-versions = true
 
 [versions]
+# FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
+# https://github.com/collective/buildout.plonetest/issues/25
+zc.recipe.cmmi = 1.3.6
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -15,6 +15,9 @@ package-name =
 show-picked-versions = true
 
 [versions]
+# FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
+# https://github.com/collective/buildout.plonetest/issues/25
+zc.recipe.cmmi = 1.3.6
 
 [instance]
 recipe = plone.recipe.zope2instance


### PR DESCRIPTION
Since zc.recipe.cmmi 2.0.0 in 2017/06/21, it asks for the newest zc.buildout
release and not all installations can afford that, so let's pin it to 1.3.6.
This version asks for at least zc.buildout 1.4, but since
http://dist.plone.org/release/4.0-latest/versions.cfg asks for 1.4.4, no harm
done.

For more info:

https://community.plone.org/t/zc-recipe-cmmi-2-0-0-released-today-21-06-2017-will-break-all-buildouts-from-plone-because-it-asks-for-zc-buildout-2-9-4-how-should-we-behave/4412/