### PR TITLE
Use https://pypi.python.org/simple/ as index.

### DIFF
--- a/plone-2.1.x.cfg
+++ b/plone-2.1.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 plone instance omelette test
 find-links =
     http://dist.plone.org

--- a/plone-2.5.x.cfg
+++ b/plone-2.5.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 plone instance test
 find-links =
     http://dist.plone.org

--- a/plone-3.1.x.cfg
+++ b/plone-3.1.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 plone instance
 find-links =
     http://dist.plone.org

--- a/plone-3.3.1.cfg
+++ b/plone-3.3.1.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 instance
 extends = http://dist.plone.org/release/3.3.1/versions.cfg
 find-links =

--- a/plone-3.3.2.cfg
+++ b/plone-3.3.2.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 instance
 extends = http://dist.plone.org/release/3.3.2/versions.cfg
 find-links =

--- a/plone-3.3.3.cfg
+++ b/plone-3.3.3.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 instance
 extends = http://dist.plone.org/release/3.3.3/versions.cfg
 find-links =

--- a/plone-3.3.4.cfg
+++ b/plone-3.3.4.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 instance
 extends = http://dist.plone.org/release/3.3.4/versions.cfg
 find-links =

--- a/plone-3.3.5.cfg
+++ b/plone-3.3.5.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 instance
 extends = http://dist.plone.org/release/3.3.5/versions.cfg
 find-links =

--- a/plone-3.3.6.cfg
+++ b/plone-3.3.6.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 instance
 extends = http://dist.plone.org/release/3.3.6/versions.cfg
 find-links =

--- a/plone-3.3.x.cfg
+++ b/plone-3.3.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends =
     http://dist.plone.org/release/3.3-latest/versions.cfg
 find-links =

--- a/plone-3.x.cfg
+++ b/plone-3.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 parts = zope2 instance
 extends = http://dist.plone.org/release/3.3.6/versions.cfg
 find-links =

--- a/plone-4.0.x.cfg
+++ b/plone-4.0.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends = http://dist.plone.org/release/4.0-latest/versions.cfg
 find-links =
     http://dist.plone.org/release/4.0-latest/

--- a/plone-4.1.x.cfg
+++ b/plone-4.1.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends = http://dist.plone.org/release/4.1-latest/versions.cfg
 find-links =
     http://dist.plone.org/release/4.1-latest/

--- a/plone-4.2.x.cfg
+++ b/plone-4.2.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends = http://dist.plone.org/release/4.2-latest/versions.cfg
 find-links =
     http://dist.plone.org/release/4.2-latest/

--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends = http://dist.plone.org/release/4.3-latest/versions.cfg
 find-links =
     http://dist.plone.org/release/4.3-latest/

--- a/plone-4.x.cfg
+++ b/plone-4.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends = http://dist.plone.org/release/4-latest/versions.cfg
 find-links =
     http://dist.plone.org/release/4-latest/

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends = http://dist.plone.org/release/5.0-latest/versions.cfg
 find-links =
     http://dist.plone.org/release/5.0-latest/

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends = http://dist.plone.org/release/5.1rc1/versions.cfg
 find-links =
     http://dist.plone.org/release/5.1rc1/

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends = http://dist.plone.org/release/5-latest/versions.cfg
 find-links =
     http://dist.plone.org/release/5-latest/

--- a/qa.cfg
+++ b/qa.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 package-min-coverage = 80
 parts +=
     code-analysis


### PR DESCRIPTION
So use https instead of http.
Otherwise no new packages can be found, unless zc.buildout 2.9.5 or higher is used.
See also https://community.plone.org/t/buildout-not-working-disabling-non-https-access-to-apis-on-pypi/5069/