### PR TITLE
Let travis-5.x.cfg use plone-series 5.2.

### DIFF
--- a/travis-5.x.cfg
+++ b/travis-5.x.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends = test-5.x.cfg buildout-cache.cfg
 parts = download install test
-plone-series = 5.1
+plone-series = 5.2
 package-name =
 package-extras =
 test-eggs =


### PR DESCRIPTION
Otherwise is creates a wrong download:
https://launchpad.net/plone/5.1/5.2.0/...
See https://github.com/collective/buildout.plonetest/issues/10#issuecomment-519732017