### PR TITLE
Removed sudo from Travis examples in readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,6 @@ And a ``.travis.yml`` like::
 
     language: python
     python: 2.7
-    sudo: false
     cache:
       pip: true
       directories:
@@ -124,7 +123,6 @@ The ``.travis.yml`` file should look like this::
     dist: bionic
     language: python
     python: 2.7
-    sudo: false
     cache:
       pip: true
       directories:
@@ -141,7 +139,6 @@ The ``.travis.yml`` file should look like this::
           env: PLONE_VERSION="5.2"
         - python: "3.7"
           env: PLONE_VERSION="5.2"
-      sudo: true
       fast_finish: true
     before_install:
       - virtualenv -p `which python` .
@@ -189,7 +186,6 @@ and update your ``.travis.yml`` like::
 
     language: python
     python: 2.7
-    sudo: false
     cache:
       pip: true
       directories:


### PR DESCRIPTION
sudo should not be used/needed anymore.
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Note that one of the items had `sudo: true` in the matrix. I never understood that. It is gone now.

Note that this is hard to test. Theoretically we could add a minimal package in this repository that uses `buildout.plonetest`. I don't see that happening in the near future though.