### PR TITLE
use Travis imports to share build config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ especially the various buildout configs and `.travis.yml <https://github.com/plo
 The intended usage is to create a ``buildout.cfg`` like::
 
     [buildout]
-    extends = https://raw.github.com/collective/buildout.plonetest/master/test-5.x.cfg
+    extends = https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.x.cfg
     package-name = plone.app.foo
 
 Create a virtualenv and run buildout.
@@ -26,7 +26,7 @@ should declare them via the ``extras_require`` parameter of
 variable::
 
     [buildout]
-    extends = https://raw.github.com/collective/buildout.plonetest/master/test-5.x.cfg
+    extends = https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.x.cfg
     package-name = plone.app.foo
     package-extras = [test]
 
@@ -54,8 +54,8 @@ helper script to update the po files of your product::
 
     [buildout]
     extends =
-        https://raw.github.com/collective/buildout.plonetest/master/test-5.x.cfg
-        https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
+        https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.x.cfg
+        https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     package-name = plone.app.foo
     package-extras = [test]
     parts+=
@@ -90,7 +90,7 @@ The ``buildout.cfg`` file in your package should look like this::
 
     [buildout]
     extends =
-        https://raw.github.com/collective/buildout.plonetest/master/test-5.x.cfg
+        https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.x.cfg
 
     package-name = collective.foo
     package-extras = [test]
@@ -142,8 +142,8 @@ update your ``travis.cfg`` file like::
 
     [buildout]
     extends =
-        https://raw.github.com/collective/buildout.plonetest/master/test-5.x.cfg
-        https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
+        https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.x.cfg
+        https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
     package-name = plone.app.foo
     package-extras = [test]
     package-min-coverage = 80

--- a/README.rst
+++ b/README.rst
@@ -33,20 +33,10 @@ variable::
 If you want to do `continuous integration`_ with `Travis CI`_ you can use this same buildout config.
 And a ``.travis.yml`` like::
 
-    language: python
-    python: 2.7
-    cache:
-      pip: true
-      directories:
-        - eggs
-    before_install:
-      - virtualenv -p `which python` .
-      - bin/pip install -r requirements.txt
-      - bin/buildout -N -t 3 annotate
-    install:
-      - bin/buildout -N -t 3
-    script:
-      - bin/test
+    version: ~> 1.0
+    import: collective/buildout.plonetest:travis/default.yml@travis-imports
+    python: "2.7"
+    env: PLONE_VERSION=5.2
 
 .. ATTENTION::
    This repository also has ``travis-*.cfg`` files, that try to be faster by downloading the Plone universal installer.
@@ -120,13 +110,8 @@ These versions match a ``requirements.txt`` like this::
 
 The ``.travis.yml`` file should look like this::
 
-    dist: bionic
-    language: python
-    python: 2.7
-    cache:
-      pip: true
-      directories:
-        - eggs
+    version: ~> 1.0
+    import: collective/buildout.plonetest:travis/default.yml@travis-imports
     matrix:
       include:
         - python: "2.7"
@@ -137,16 +122,6 @@ The ``.travis.yml`` file should look like this::
           env: PLONE_VERSION="5.2"
         - python: "3.7"
           env: PLONE_VERSION="5.2"
-      fast_finish: true
-    before_install:
-      - virtualenv -p `which python` .
-      - bin/pip install -r requirements.txt
-      - sed -ie "s#test-5.x.cfg#test-$PLONE_VERSION.x.cfg#" buildout.cfg
-      - bin/buildout -N -t 3 annotate
-    install:
-      - bin/buildout -N -t 3
-    script:
-      - bin/test
 
 The trick here is to replace the extended configuration with the right one
 using the `sed`_ command.

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ If you want to do `continuous integration`_ with `Travis CI`_ you can use this s
 And a ``.travis.yml`` like::
 
     version: ~> 1.0
-    import: collective/buildout.plonetest:travis/default.yml@travis-imports
+    import: collective/buildout.plonetest:travis/default.yml
     python: "2.7"
     env: PLONE_VERSION=5.2
 
@@ -111,7 +111,7 @@ These versions match a ``requirements.txt`` like this::
 The ``.travis.yml`` file should look like this::
 
     version: ~> 1.0
-    import: collective/buildout.plonetest:travis/default.yml@travis-imports
+    import: collective/buildout.plonetest:travis/default.yml
     matrix:
       include:
         - python: "2.7"

--- a/travis/default.yml
+++ b/travis/default.yml
@@ -1,0 +1,20 @@
+version: ~> 1.0
+language: python
+sudo: false
+cache:
+  pip: true
+  directories:
+    - eggs
+before_install:
+  - pip install -r requirements.txt
+  - cp test-$PLONE_VERSION.cfg buildout.cfg
+  - buildout -N -t 3 annotate
+install:
+  - buildout -N -t 3
+script:
+  - bin/test --all
+after_script:
+  - bin/createcoverage --output-dir=parts/test/coverage
+after_success:
+  - pip install -q coveralls
+  - coveralls

--- a/travis/default.yml
+++ b/travis/default.yml
@@ -14,10 +14,10 @@ install:
   - bin/buildout -N -t 3
 script:
   - bin/test --all
-after_script:
-  - bin/createcoverage --output-dir=parts/test/coverage
 after_success:
+  - bin/createcoverage --output-dir=parts/test/coverage
   - pip install -q coveralls
   - coveralls
 matrix:
   fast_finish: true
+  

--- a/travis/default.yml
+++ b/travis/default.yml
@@ -18,3 +18,5 @@ after_script:
 after_success:
   - pip install -q coveralls
   - coveralls
+matrix:
+  fast_finish: true

--- a/travis/default.yml
+++ b/travis/default.yml
@@ -6,11 +6,12 @@ cache:
   directories:
     - eggs
 before_install:
-  - pip install -r requirements.txt
-  - cp test-$PLONE_VERSION.cfg buildout.cfg
-  - buildout -N -t 3 annotate
+  - virtualenv -p `which python` .
+  - bin/pip install -r requirements.txt
+  - sed -ie "s#test-5.x.cfg#test-$PLONE_VERSION.x.cfg#" buildout.cfg
+  - bin/buildout -N -t 3 annotate
 install:
-  - buildout -N -t 3
+  - bin/buildout -N -t 3
 script:
   - bin/test --all
 after_script:


### PR DESCRIPTION
Travis implements sthing similar to ``buildout extends``

See: https://blog.travis-ci.com/2019-11-11-build-config-imports