### PR TITLE
Unpinning flake8 in qa.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*project

--- a/qa.cfg
+++ b/qa.cfg
@@ -125,7 +125,3 @@ input = inline:
             bin/i18ndude sync --pot $pot_file $po
         done
     fi
-
-[versions]
-flake8 = 3.3.0
-pycodestyle = 2.0.0


### PR DESCRIPTION
The Plone 5 `setuptools` version is already the required by `flake8`.

In Plone 4, packages should take care of this.