### PR TITLE
Remove `newest = false` to use the default `newest = true`

### DIFF
--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -13,7 +13,6 @@ parts = instance
 
 package-name =
 
-newest = false
 show-picked-versions = true
 
 [versions]

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -13,7 +13,6 @@ parts = instance
 
 package-name =
 
-newest = false
 show-picked-versions = true
 
 [versions]

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -13,7 +13,6 @@ parts = instance
 
 package-name =
 
-newest = false
 show-picked-versions = true
 
 plone-user = admin:admin

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -13,7 +13,6 @@ parts = instance
 
 package-name =
 
-newest = false
 show-picked-versions = true
 
 [versions]


### PR DESCRIPTION
To avoid restart problems, just install the buildout with pip and use in `requirements.txt`, the same versions of `setuptools/buildout` pinned in buildout.

Fix #60