### PR TITLE
Pin zipp < 2.0.0

### DIFF
--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -20,6 +20,7 @@ show-picked-versions = true
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6
+zipp = <2.0.0
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-4.x.cfg
+++ b/plone-4.x.cfg
@@ -19,6 +19,7 @@ show-picked-versions = true
 [versions]
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6
+zipp = <2.0.0
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -19,6 +19,7 @@ show-picked-versions = true
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6
+zipp = <2.0.0
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -19,6 +19,7 @@ show-picked-versions = true
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6
+zipp = <2.0.0
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -22,6 +22,9 @@ plone-user = admin:admin
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6
 
+[versions:python27]
+zipp = <2.0.0
+
 [instance]
 recipe = plone.recipe.zope2instance
 user = ${buildout:plone-user}

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -20,6 +20,9 @@ show-picked-versions = true
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6
 
+[versions:python27]
+zipp = <2.0.0
+
 [instance]
 recipe = plone.recipe.zope2instance
 user = admin:admin


### PR DESCRIPTION
`zipp >= 2.0.0` is not compatible with Python 2. See:

https://github.com/jaraco/zipp/blob/4759ee957b237d9f14b3da1596f66f837fc52d93/setup.cfg#L14

When `zipp` is installed with the current setuptools/buildout combination from https://dist.plone.org/release/5.1-latest/requirements.txt:

```
setuptools==40.8.0
zc.buildout==2.13.1
```
the error occurs:
```
Getting distribution for 'zipp'.
zip_safe flag not set; analyzing archive contents...
While:
  Installing.
  Getting section code-analysis.
  Initializing section code-analysis.
  Installing recipe plone.recipe.codeanalysis.
  Getting distribution for 'zipp'.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/buildout.py", line 2174, in main
    getattr(buildout, command)(args)
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/buildout.py", line 701, in install
    [self[part]['recipe'] for part in install_parts]
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/buildout.py", line 1324, in __getitem__
    options._initialize()
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/buildout.py", line 1432, in _initialize
    self.initialize()
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/buildout.py", line 1438, in initialize
    recipe_class = _install_and_load(reqs, 'zc.buildout', entry, buildout)
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/buildout.py", line 1388, in _install_and_load
    allow_hosts=buildout._allow_hosts
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 957, in install
    return installer.install(specs, working_set)
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 730, in install
    for dist in self._get_dist(req, ws):
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 574, in _get_dist
    dists = [_move_to_eggs_dir_and_compile(dist, self._dest)]
  File "/home/user/git/collective.elasticsearch/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 1771, in _move_to_eggs_dir_and_compile
    assert newdist is not None  # newloc above is missing our dist?!
AssertionError
```

When using the latest versions of setuptools/buildout:

```
setuptools==44.0.0
zc.buildout==2.13.3
```

the error doesn't occur but it wrong installs version 3.0.0.