### PR TITLE
Remove flake8-ignore setting

### DIFF
--- a/qa.cfg
+++ b/qa.cfg
@@ -10,7 +10,6 @@ recipe = plone.recipe.codeanalysis
 directory = src
 pre-commit-hook = True
 flake8 = True
-flake8-ignore = E501
 return-status-codes = True
 
 [createcoverage]


### PR DESCRIPTION
This should be set in `setup.cfg`, `tox.ini` or `.flake8`. Unsetting in a custom config is not possible once set.

If you try to unset it later with e.g.
```
flake8-ignore =
```
it is still added to the list of flake8 options and written to the generated command:
```
'flake8-ignore': '',
```
 This then overrides any settings in `setup.cfg`, `tox.ini` or `.flake8`.