### PR TITLE
Pin isort = 4.3.20 for Python 2

### DIFF
--- a/qa.cfg
+++ b/qa.cfg
@@ -129,3 +129,4 @@ input = inline:
 
 [versions:python27]
 configparser = <5.0.0
+isort = <5.0.0


### PR DESCRIPTION
Newest versions aren't compatible with Python 2 See:

https://github.com/timothycrosley/isort/blob/2952db41650211984fe64ac0b856881627e55aeb/pyproject.toml#L27