### PR TITLE
Pin check-manifest to 0.41 on Python 2.7.

### DIFF
--- a/plone-4.3.x.cfg
+++ b/plone-4.3.x.cfg
@@ -17,6 +17,7 @@ package-name =
 show-picked-versions = true
 
 [versions]
+check-manifest = 0.41
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6

--- a/plone-4.x.cfg
+++ b/plone-4.x.cfg
@@ -17,6 +17,7 @@ package-name =
 show-picked-versions = true
 
 [versions]
+check-manifest = 0.41
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6
 zipp = <2.0.0

--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -16,6 +16,7 @@ package-name =
 show-picked-versions = true
 
 [versions]
+check-manifest = 0.41
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -16,6 +16,7 @@ package-name =
 show-picked-versions = true
 
 [versions]
+check-manifest = 0.41
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.
 # https://github.com/collective/buildout.plonetest/issues/25
 zc.recipe.cmmi = 1.3.6

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -23,6 +23,7 @@ plone-user = admin:admin
 zc.recipe.cmmi = 1.3.6
 
 [versions:python27]
+check-manifest = 0.41
 zipp = <2.0.0
 
 [instance]

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -21,6 +21,7 @@ show-picked-versions = true
 zc.recipe.cmmi = 1.3.6
 
 [versions:python27]
+check-manifest = 0.41
 zipp = <2.0.0
 
 [instance]


### PR DESCRIPTION
That is the last version that is compatible with 2.7.
Also, 0.45+ pulls in newer version of packages like 'build' and 'pep517', and 'virtualenv'.

For a sample error, see this [easyform run on 5.1](https://travis-ci.org/github/collective/collective.easyform/jobs/743916981).