### PR TITLE
Pinn importlib-metadata = 2.1.1 in Plone 5.0

### DIFF
--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -17,6 +17,9 @@ show-picked-versions = true
 
 [versions]
 check-manifest = 0.41
+# Latest version compatible with Python 2.
+# Other versions of Plone already pin this package.
+importlib-metadata = 2.1.1
 # Latest version compatible with Python 2
 watchdog = 0.10.6
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.


### PR DESCRIPTION
Latest version compatible with Python 2. See:

https://github.com/python/importlib_metadata/blob/530f5da8dd3a255f1198f29ea0126b8b25e644d8/setup.cfg#L14

Other versions of Plone already pin this package.