### PR TITLE
Remove index on Plone 5

### DIFF
--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -1,5 +1,4 @@
 [buildout]
-index = https://pypi.org/simple/
 extends = https://dist.plone.org/release/5.0-latest/versions.cfg
 find-links =
     https://dist.plone.org/release/5.0-latest/

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -1,5 +1,4 @@
 [buildout]
-index = https://pypi.org/simple/
 extends = https://dist.plone.org/release/5.1-latest/versions.cfg
 find-links =
     https://dist.plone.org/release/5.1-latest/

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -1,5 +1,4 @@
 [buildout]
-index = https://pypi.org/simple/
 extends = https://dist.plone.org/release/5.2-latest/versions.cfg
 find-links =
     https://dist.plone.org/release/5.2-latest/

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -1,5 +1,4 @@
 [buildout]
-index = https://pypi.org/simple/
 extends = https://dist.plone.org/release/5-latest/versions.cfg
 find-links =
     https://dist.plone.org/release/5-latest/

--- a/qa.cfg
+++ b/qa.cfg
@@ -1,5 +1,4 @@
 [buildout]
-index = https://pypi.org/simple/
 package-min-coverage = 80
 versions = versions
 parts +=


### PR DESCRIPTION
This is already default value of the buildout versions used by Plone 5.
See:

https://github.com/buildout/buildout/blob/6e00617ec15cb23dd3fd00b159e1df3497b72e1f/src/zc/buildout/easy_install.py#L64-L67