### PR TITLE
Unpinned pycodestyle in Plone 5.0

### DIFF
--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -19,6 +19,11 @@ check-manifest = 0.41
 # Latest version compatible with Python 2.
 # Other versions of Plone already pin this package.
 importlib-metadata = 2.1.1
+
+# Plone 5.0-latest pinn pycodestyle = 2.3.1 but new versions of flake8 always
+# require the latest version of pycodestyle.
+pycodestyle =
+
 # Latest version compatible with Python 2
 watchdog = 0.10.6
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.


### PR DESCRIPTION
Plone 5.0-latest pinn `pycodestyle = 2.3.1` but new versions of `flake8` always require the latest version of `pycodestyle`. See:

https://github.com/PyCQA/flake8/blob/3.9.2/setup.cfg#L45

This fix error:

```bash
Getting distribution for 'flake8>=2.4.0'.
Got flake8 3.9.2.
Version and requirements information containing pycodestyle:
  [versions] constraint on pycodestyle: 2.3.1
  Requirement of flake8>=2.4.0: pycodestyle<2.8.0,>=2.7.0
While:
  Installing.
  Getting section code-analysis.
  Initializing section code-analysis.
  Installing recipe plone.recipe.codeanalysis.
Error: The requirement ('pycodestyle<2.8.0,>=2.7.0') is not allowed by your [versions] constraint (2.3.1)
```