### PR TITLE
Removes unnecessary pinns in Plone 5.2

### DIFF
--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -22,9 +22,6 @@ plone-user = admin:admin
 zc.recipe.cmmi = 1.3.6
 
 [versions:python27]
-check-manifest = 0.41
-# Latest version compatible with Python 2
-watchdog = 0.10.6
 zipp = <2.0.0
 
 [instance]

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -20,9 +20,6 @@ show-picked-versions = true
 zc.recipe.cmmi = 1.3.6
 
 [versions:python27]
-check-manifest = 0.41
-# Latest version compatible with Python 2
-watchdog = 0.10.6
 zipp = <2.0.0
 
 [instance]


### PR DESCRIPTION
`check-manifest` and `watchdog` are already pinned at:

https://dist.plone.org/release/5.2-latest/versions.cfg

See:

https://github.com/plone/buildout.coredev/blob/8b7ab4c42a0bd62c106ed67c987d0f3cc4519c16/versions.cfg#L339