### PR TITLE
Pin flake8 and dependencies to work in Python 2

### DIFF
--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -20,10 +20,6 @@ check-manifest = 0.41
 # Other versions of Plone already pin this package.
 importlib-metadata = 2.1.1
 
-# Plone 5.0-latest pinn pycodestyle = 2.3.1 but new versions of flake8 always
-# require the latest version of pycodestyle.
-pycodestyle =
-
 # Latest version compatible with Python 2
 watchdog = 0.10.6
 # FIXME: This can be removed if Plone folks add the pin to Plone official cfgs.

--- a/qa.cfg
+++ b/qa.cfg
@@ -128,4 +128,7 @@ input = inline:
 
 [versions:python27]
 configparser = <5.0.0
+flake8 = 3.9.2
+flake8-isort = 4.0.0
 isort = <5.0.0
+pycodestyle = 2.7.0


### PR DESCRIPTION
`flake8 >= 4.0.0` drop support to Python 2. See:

https://github.com/PyCQA/flake8/blob/960cf8cf2044359d5fbd3454a2a9a1d7a0586594/setup.cfg#L22

`flake8-isort >= 4.1.0` drop support to Python 2. See:

https://github.com/gforcada/flake8-isort/blob/b5a989a9e5170fd34e24754bc98413ea3fc1c12b/setup.py#L38

`flake8 = 3.9.2` requires `pycodestyle = 2.7.0`: See:

https://github.com/PyCQA/flake8/blob/3.9.2/setup.cfg#L45