### PR TITLE
Use wsgi = on in Plone 5.2 with Python 2

### DIFF
--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -27,7 +27,6 @@ zipp = <2.0.0
 [instance]
 recipe = plone.recipe.zope2instance
 user = ${buildout:plone-user}
-wsgi = on
 eggs =
     Plone
     plone.app.upgrade
@@ -36,21 +35,5 @@ eggs =
 deprecation-warnings = on
 environment-vars =
     zope_i18n_compile_mo_files true
-zcml =
-    ${buildout:package-name}
-
-[instance:python27]
-recipe = plone.recipe.zope2instance
-user = ${buildout:plone-user}
-wsgi = off
-eggs =
-    Plone
-    plone.app.upgrade
-    ${buildout:package-name}
-    ${buildout:eggs}
-deprecation-warnings = on
-environment-vars =
-    zope_i18n_compile_mo_files true
-resources = ${buildout:directory}/resources
 zcml =
     ${buildout:package-name}

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -25,7 +25,6 @@ plone-user = admin:admin
 [instance]
 recipe = plone.recipe.zope2instance
 user = ${buildout:plone-user}
-wsgi = on
 eggs =
     Plone
     plone.app.upgrade


### PR DESCRIPTION
`wsgi = off` is not working in Plone 5.2 with Python 2. I get the error below after creating a Plone Site:

```bash
Traceback (most recent call last):
  File "/home/user/.buildout/eggs/cp27mu/ZServer-4.0.2-py2.7.egg/ZServer/PubCore/ZServerPublisher.py", line 32, in __init__
    response=b)
  File "/home/user/.buildout/eggs/cp27mu/ZServer-4.0.2-py2.7.egg/ZServer/ZPublisher/Publish.py", line 404, in publish_module
    environ, debug, request, response)
  File "/home/user/.buildout/eggs/cp27mu/ZServer-4.0.2-py2.7.egg/ZServer/ZPublisher/Publish.py", line 279, in publish_module_standard
    outputBody()
  File "/home/user/.buildout/eggs/cp27mu/ZServer-4.0.2-py2.7.egg/ZServer/HTTPResponse.py", line 252, in outputBody
    self.stdout.write(str(self))
  File "/home/user/.buildout/eggs/cp27mu/ZServer-4.0.2-py2.7.egg/ZServer/HTTPResponse.py", line 145, in __str__
    return "\r\n".join(chunks)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 198: ordinal not in range(128)
```