### PR TITLE
Pin flake8-quotes 3.3.0 in Python 2

### DIFF
--- a/qa.cfg
+++ b/qa.cfg
@@ -130,5 +130,6 @@ input = inline:
 configparser = <5.0.0
 flake8 = 3.9.2
 flake8-isort = 4.0.0
+flake8-quotes = 3.3.0
 isort = <5.0.0
 pycodestyle = 2.7.0


### PR DESCRIPTION
`flake8-quotes 3.3.1` drop support to Python 2. See:

https://github.com/zheller/flake8-quotes/blob/3.3.1/setup.py#L54-L63