### PR TITLE
Unpinned configparser in Plone 5.2, 5.1 and 4.3

### DIFF
--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -15,6 +15,7 @@ package-name =
 show-picked-versions = true
 
 [versions]
+configparser = <5.0.0
 check-manifest = 0.41
 # Latest version compatible with Python 2.
 # Other versions of Plone already pin this package.

--- a/qa.cfg
+++ b/qa.cfg
@@ -127,7 +127,6 @@ input = inline:
     fi
 
 [versions:python27]
-configparser = <5.0.0
 flake8 = 3.9.2
 flake8-isort = 4.0.0
 flake8-quotes = 3.3.0


### PR DESCRIPTION
The versions of `Zope` used by Plone 5.2, 5.1 and 4.3 already pin a Python 2 compatible version of `configparser`. So let's let it take care of that pin.

Plone 5.2: https://github.com/zopefoundation/Zope/blob/bcb337eee5cc78a77636d6b2f9d5e558d6b578d5/versions.cfg#L36
Plone 5.1: https://dist.plone.org/versions/zope-2-13-30-versions.cfg
Plone 4.3: https://dist.plone.org/versions/zope-2-13-30-versions.cfg