### PR TITLE
Remove 'versions = versions' in Plone >= 5.0

### DIFF
--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -6,7 +6,6 @@ find-links =
 
 develop = .
 eggs =
-versions = versions
 
 parts = instance
 

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -6,7 +6,6 @@ find-links =
 
 develop = .
 eggs =
-versions = versions
 
 parts = instance
 

--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -6,7 +6,6 @@ find-links =
 
 develop = .
 eggs =
-versions = versions
 
 parts = instance
 

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -6,7 +6,6 @@ find-links =
 
 develop = .
 eggs =
-versions = versions
 
 parts = instance
 

--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -6,7 +6,6 @@ find-links =
 
 develop = .
 eggs =
-versions = versions
 
 parts = instance
 

--- a/qa.cfg
+++ b/qa.cfg
@@ -1,6 +1,5 @@
 [buildout]
 package-min-coverage = 80
-versions = versions
 parts +=
     code-analysis
     i18ndude


### PR DESCRIPTION
As of `zc.buildout 2.0.0`, the "versions" value is the default of `versions` option. See: 

https://github.com/buildout/buildout/blob/2.0.0/CHANGES.rst#200-2013-02-10

Since Plone >= 5.0, `zc.buildout` is already `> 2.0.0`. See:

https://github.com/plone/buildout.coredev/blob/5.0/versions.cfg#L35