### PR TITLE
Fixes pins of coverage and check-manifest in Python 2

### DIFF
--- a/plone-5.2.x.cfg
+++ b/plone-5.2.x.cfg
@@ -16,6 +16,7 @@ show-picked-versions = true
 plone-user = admin:admin
 
 [versions:python27]
+coverage = 5.5
 zipp = <2.0.0
 
 [instance]

--- a/plone-5.x.cfg
+++ b/plone-5.x.cfg
@@ -14,6 +14,7 @@ package-name =
 show-picked-versions = true
 
 [versions:python27]
+coverage = 5.5
 zipp = <2.0.0
 
 [instance]

--- a/qa.cfg
+++ b/qa.cfg
@@ -131,5 +131,3 @@ flake8-isort = 4.0.0
 flake8-quotes = 3.3.0
 isort = <5.0.0
 pycodestyle = 2.7.0
-check-manifest = <0.42
-coverage = >=3.7, <6


### PR DESCRIPTION
`coverage` is already pinned in Plone < 5.2. So we pin it only to `plone-5.2.x.cfg`.

`check-manifest` is already pinned in Plone 5.2. In Plone < 5.2 it is already pinned in `plone-x.x.x.cfg`. So it is not necessary to pin on `qa.cfg`. See:

https://github.com/collective/buildout.plonetest/blob/e728743e79e3f28e310191f82c435c30ccd0e034/plone-5.1.x.cfg#L17

https://github.com/collective/buildout.plonetest/blob/e728743e79e3f28e310191f82c435c30ccd0e034/plone-5.0.x.cfg#L18

https://github.com/collective/buildout.plonetest/blob/37a8da2ef56cadc465380c0896b706bb04ae926d/plone-4.3.x.cfg#L20

