### PR TITLE
Pinn contextlib2 = 0.6.0.post1 in Plone 5.0

### DIFF
--- a/plone-5.0.x.cfg
+++ b/plone-5.0.x.cfg
@@ -15,6 +15,7 @@ show-picked-versions = true
 
 [versions]
 configparser = <5.0.0
+contextlib2 = 0.6.0.post1
 check-manifest = 0.41
 # Latest version compatible with Python 2.
 # Other versions of Plone already pin this package.


### PR DESCRIPTION
`contextlib2` > 0.6.0.post1 is not compatible with Python 2. See:

https://github.com/jazzband/contextlib2/blob/21.6.0/setup.py#L25

Zope from other versions of Plone already pin `contextlib2` compatible with Python 2. See:

https://github.com/zopefoundation/Zope/blob/4.6.3/versions.cfg#L36