### PR TITLE
Make rebuild_i18n.sh fail if i18ndude fail

### DIFF
--- a/qa.cfg
+++ b/qa.cfg
@@ -73,7 +73,7 @@ recipe = collective.recipe.template
 output = ${buildout:directory}/bin/rebuild_i18n.sh
 mode = 755
 input = inline:
-    #! /bin/sh
+    #! /bin/sh -e
     # see http://maurits.vanrees.org/weblog/archive/2010/10/i18n-plone-4 for more information
 
     I18NDOMAIN="${buildout:package-name}"


### PR DESCRIPTION
Sometimes the ``i18ndude`` command fails but ``rebuild_i18n.sh`` returns 0. We use ``rebuild_i18n.sh`` on our CI to verify that all translations have been add. The build was passing, even with the ``i18ndude`` error. With ``#! /bin/sh -e`` rebuild_i18n.sh will stop running when an error occurs and return 1.