### PR TITLE
Add files.pythonhosted.org to allow-hosts in Plone 6

### DIFF
--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -15,6 +15,10 @@ show-picked-versions = true
 
 plone-user = admin:admin
 
+allow-hosts =
+    pypi.org
+    files.pythonhosted.org
+
 [instance]
 recipe = plone.recipe.zope2instance
 user = ${buildout:plone-user}


### PR DESCRIPTION
In some cases, files are found there. See:

https://github.com/plone/plone.autoinclude/issues/18