### PR TITLE
Removed https://dist.plone.org/thirdparty/ from find-links in Plone 6.

### DIFF
--- a/plone-6.0.x.cfg
+++ b/plone-6.0.x.cfg
@@ -2,7 +2,6 @@
 extends = https://dist.plone.org/release/6.0-dev/versions.cfg
 find-links =
     https://dist.plone.org/release/6.0-dev/
-    https://dist.plone.org/thirdparty/
 
 develop = .
 eggs =


### PR DESCRIPTION
There is nothing there for us.
Should be fine to remove in Plone 4 and 5 as well, but let's err on the safe side.