### PR TITLE
Pin zest.releaser dependencies in Plone 5.1

### DIFF
--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -14,7 +14,9 @@ package-name =
 show-picked-versions = true
 
 [versions]
+bleach = 3.3.1
 check-manifest = 0.41
+pyparsing = 2.4.7
 # Latest version compatible with Python 2
 watchdog = 0.10.6
 zipp = <2.0.0


### PR DESCRIPTION
Pin `bleach = 3.3.1` and `pyparsing = 2.4.7`, which are Python 2 compatible `zest.releaser` dependencies.