### PR TITLE
Pinn flake8-debugger = 3.2.1 and flake8-print = 3.1.4 in Python 2.7

### DIFF
--- a/qa.cfg
+++ b/qa.cfg
@@ -127,7 +127,9 @@ input = inline:
 
 [versions:python27]
 flake8 = 3.9.2
+flake8-debugger = 3.2.1
 flake8-isort = 4.0.0
+flake8-print = 3.1.4
 flake8-quotes = 3.3.0
 isort = <5.0.0
 pycodestyle = 2.7.0


### PR DESCRIPTION
These are the latest `Python 2.7` compatible versions.

See:

https://github.com/jbkahn/flake8-debugger#400---2020-11-29

https://github.com/jbkahn/flake8-print#400---2020-11-29