### PR TITLE
Pin Python 2 compatible versions of flake8 plugin packages

### DIFF
--- a/qa.cfg
+++ b/qa.cfg
@@ -128,7 +128,11 @@ input = inline:
 [versions:python27]
 flake8 = 3.9.2
 flake8-debugger = 3.2.1
+flake8-deprecated= 1.3
 flake8-isort = 4.0.0
+flake8-pep3101 = 1.3.0
+flake8-plone-api = 1.4
+flake8-plone-hasattr = 0.2
 flake8-print = 3.1.4
 flake8-quotes = 3.3.0
 isort = <5.0.0


### PR DESCRIPTION
flake8-plone-hasattr = 0.2
flake8-plone-api = 1.4
flake8-pep3101 = 1.3.0
flake8-deprecated= 1.3

New versions of this packages are not compatible with Python 2.